### PR TITLE
コマンドを送信出来ない問題を修正

### DIFF
--- a/minecraft.sh
+++ b/minecraft.sh
@@ -5,7 +5,7 @@ source ./minecraft.conf
 # This function is send command to Minecraft session on screen
 # ex. send_cmd "say Hello"
 function send_cmd {
-  screen -S $SESSION_NAME -p 0 -X eval 'stuff "$1\015\"'
+  eval "screen -S $SESSION_NAME -p 0 -X eval 'stuff \"$1\015\"'"
 }
 
 function send_msg {


### PR DESCRIPTION
Fix #5 
Fix #6 

シングルクォート内だったため`$1`が展開されなかったのが問題だったようです。
`send_cmd`内の処理を`eval`を使うようにして解決しました。